### PR TITLE
Improve setup scripts with pyenv environment and token prompts

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -1,6 +1,22 @@
 @echo off
 setlocal enabledelayedexpansion
 
+REM Ensure pyenv and Python are available
+set "PYENV=%USERPROFILE%\.pyenv"
+set "PATH=%PYENV%\pyenv-win\bin;%PYENV%\pyenv-win\shims;%PATH%"
+
+where pyenv >nul 2>&1
+if errorlevel 1 (
+    echo pyenv not found. Installing...
+    powershell -NoProfile -ExecutionPolicy Bypass -Command "Invoke-WebRequest -UseBasicParsing https://pyenv.win/install.ps1 ^| Invoke-Expression"
+    set "PATH=%PYENV%\pyenv-win\bin;%PYENV%\pyenv-win\shims;%PATH%"
+)
+
+set "PY_VERSION=3.11.6"
+pyenv install -s %PY_VERSION% || exit /b 1
+pyenv virtualenv -f %PY_VERSION% unitybot-env >nul 2>&1 || exit /b 1
+pyenv local unitybot-env || exit /b 1
+
 echo Use .env file for configuration? (Y/N):
 set /p use_env=
 if /I "%use_env%"=="Y" (
@@ -12,30 +28,41 @@ if /I "%use_env%"=="Y" (
 call :prompt_var DISCORD_TOKEN
 call :prompt_var POLLINATIONS_TOKEN
 
-pip install -r requirements.txt
+pip install -r requirements.txt || exit /b 1
 
 echo Setup complete.
 pause
 goto :eof
 
 :prompt_var
-set var=%1
-if "%TARGET%"=="system" (
-    for /f "tokens=2 delims==" %%A in ('set %var% 2^>nul') do set current=%%A
-    if defined current (
+set "var=%~1"
+set "env_value="
+for /f "tokens=2 delims==" %%A in ('set %var% 2^>nul') do set "env_value=%%A"
+
+if "%TARGET%"=="env" (
+    set "file_value="
+    if exist .env (
+        for /f "tokens=2 delims==" %%A in ('findstr /b "%var%=" .env') do set "file_value=%%A"
+    )
+    if defined file_value (
+        echo %var% already set in .env. Skipping prompt.
+    ) else (
+        set /p value=Enter value for %var%:
+        if "!value!"=="" if defined env_value set "value=!env_value!"
+        if exist .env (
+            findstr /v /b "%var%=" .env > .env.tmp
+            move /y .env.tmp .env >nul
+        )
+        echo %var%=%value%>>.env
+    )
+) else (
+    if defined env_value (
         echo %var% already set. Skipping prompt.
     ) else (
         set /p value=Enter value for %var%:
         setx %var% "%value%" >nul
-        set %var%=%value%
+        set "%var%=%value%"
     )
-) else (
-    if exist .env (
-        findstr /v /b "%var%=" .env > .env.tmp
-        move /y .env.tmp .env >nul
-    )
-    set /p value=Enter value for %var%:
-    echo %var%=%value%>>.env
 )
 goto :eof
 

--- a/setup.sh
+++ b/setup.sh
@@ -11,31 +11,56 @@ else
     TARGET="system"
 fi
 
+# Ensure pyenv and Python are available
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+if ! command -v pyenv >/dev/null; then
+    echo "pyenv not found. Installing..."
+    curl https://pyenv.run | bash || { echo "Failed to install pyenv"; exit 1; }
+    export PATH="$PYENV_ROOT/bin:$PATH"
+fi
+
+if command -v pyenv >/dev/null; then
+    eval "$(pyenv init -)"
+    eval "$(pyenv virtualenv-init -)"
+    PY_VERSION="3.11.6"
+    pyenv install -s "$PY_VERSION"
+    if ! pyenv virtualenvs --bare | grep -q "^unitybot-env$"; then
+        pyenv virtualenv "$PY_VERSION" unitybot-env
+    fi
+    pyenv local unitybot-env
+else
+    echo "pyenv installation failed. Exiting."
+    exit 1
+fi
+
 prompt_var() {
     local var_name=$1
-    local current=""
-    if [[ "$TARGET" == "system" ]]; then
-        current=$(printenv "$var_name")
-    else
-        [[ -f .env ]] && current=$(grep -E "^${var_name}=" .env | cut -d'=' -f2-)
-    fi
+    local env_val=$(printenv "$var_name")
+    local file_val=""
+    [[ -f .env ]] && file_val=$(grep -E "^${var_name}=" .env | cut -d'=' -f2-)
 
-    if [[ -n "$current" ]]; then
-        echo "$var_name already set. Skipping prompt."
-        return
-    fi
-
-    read -p "Enter value for $var_name: " value
-    if [[ "$TARGET" == "system" ]]; then
-        if grep -q "^$var_name=" /etc/environment 2>/dev/null; then
-            sudo sed -i "s/^$var_name=.*/$var_name=\"$value\"/" /etc/environment
+    if [[ "$TARGET" == "env" ]]; then
+        if [[ -n "$file_val" ]]; then
+            echo "$var_name already set in .env. Skipping prompt."
         else
-            echo "$var_name=\"$value\"" | sudo tee -a /etc/environment >/dev/null
+            read -p "Enter value for $var_name${env_val:+ [$env_val]}: " value
+            value=${value:-$env_val}
+            [[ -f .env ]] && grep -v "^$var_name=" .env > .env.tmp && mv .env.tmp .env
+            echo "$var_name=$value" >> .env
         fi
-        export "$var_name"="$value"
     else
-        [[ -f .env ]] && grep -v "^$var_name=" .env > .env.tmp && mv .env.tmp .env
-        echo "$var_name=$value" >> .env
+        if [[ -n "$env_val" ]]; then
+            echo "$var_name already set. Skipping prompt."
+        else
+            read -p "Enter value for $var_name: " value
+            if grep -q "^$var_name=" /etc/environment 2>/dev/null; then
+                sudo sed -i "s/^$var_name=.*/$var_name=\"${value}\"/" /etc/environment
+            else
+                echo "$var_name=\"${value}\"" | sudo tee -a /etc/environment >/dev/null
+            fi
+            export "$var_name"="$value"
+        fi
     fi
 }
 


### PR DESCRIPTION
## Summary
- Ensure Python/pyenv environment is prepared before installing packages in setup scripts
- Prompt for missing DISCORD_TOKEN and POLLINATIONS_TOKEN whether using system env or .env file

## Testing
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_b_68952878a10883299e0d6eb6c8bf5dc3