### PR TITLE
fix: ensure venv setup and systemd integration

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,12 @@ set -e
 SERVICE_NAME="unitybot"
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
+VENV_PYTHON="${SCRIPT_DIR}/.venv/bin/python"
+if [ ! -x "$VENV_PYTHON" ]; then
+    echo "Virtual environment not found. Run setup.sh before installing the service." >&2
+    exit 1
+fi
+
 cat <<EOF | sudo tee /etc/systemd/system/${SERVICE_NAME}.service >/dev/null
 [Unit]
 Description=UnityBot Discord Bot
@@ -14,7 +20,9 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=${SCRIPT_DIR}
-ExecStart=$(command -v python3) ${SCRIPT_DIR}/bot.py
+EnvironmentFile=-${SCRIPT_DIR}/.env
+EnvironmentFile=-/etc/environment
+ExecStart=${VENV_PYTHON} ${SCRIPT_DIR}/bot.py
 Restart=on-failure
 
 [Install]

--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,7 @@ else
     TARGET="system"
 fi
 
-# Ensure system Python is available without compiling
+# Ensure system Python and required modules are available
 if ! command -v python3 >/dev/null; then
     echo "python3 not found. Installing..."
     if command -v apt-get >/dev/null; then
@@ -19,6 +19,26 @@ if ! command -v python3 >/dev/null; then
     else
         echo "Package manager not supported. Please install Python 3.8+ manually." >&2
         exit 1
+    fi
+else
+    # python3 present – ensure venv and pip modules are available
+    if ! python3 -m venv --help >/dev/null 2>&1; then
+        if command -v apt-get >/dev/null; then
+            echo "python3-venv not found. Installing..."
+            sudo apt-get update && sudo apt-get install -y python3-venv
+        else
+            echo "python3-venv is required but could not be installed automatically." >&2
+            exit 1
+        fi
+    fi
+    if ! python3 -m pip --version >/dev/null 2>&1; then
+        if command -v apt-get >/dev/null; then
+            echo "python3-pip not found. Installing..."
+            sudo apt-get update && sudo apt-get install -y python3-pip
+        else
+            echo "python3-pip is required but could not be installed automatically." >&2
+            exit 1
+        fi
     fi
 fi
 
@@ -34,7 +54,7 @@ fi
 
 # Create and activate virtual environment
 if [ ! -d .venv ]; then
-    python3 -m venv .venv
+    python3 -m venv .venv || { echo "Failed to create virtual environment" >&2; exit 1; }
 fi
 source .venv/bin/activate
 


### PR DESCRIPTION
## Summary
- ensure setup script installs python3-venv and pip when missing
- create virtual environment reliably and fail fast
- run service using venv python and load env vars

## Testing
- `printf "y\n${DISCORD}\n${POLL}\n" | bash setup.sh`
- `printf "n\n${DISCORD}\n${POLL}\n" | bash setup.sh`
- `bash install.sh` *(fails: System has not been booted with systemd as init system (PID 1). Can't operate.)*

------
https://chatgpt.com/codex/tasks/task_b_68954dc9a0088329be39283b4e3a339d