### PR TITLE
Ensure setup scripts run from their own directory

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -1,6 +1,10 @@
 @echo off
 setlocal enabledelayedexpansion
 
+REM Ensure the script runs from its own directory
+set "SCRIPT_DIR=%~dp0"
+cd /d "%SCRIPT_DIR%"
+
 REM Ensure Python is available without compiling
 where python >nul 2>&1
 if errorlevel 1 (


### PR DESCRIPTION
## Summary
- run both Linux and Windows setup scripts from their own directory to avoid missing files when invoked elsewhere
- harden Linux setup script with safer `read -r`, direct Python version check, and shellcheck compliance

## Testing
- `bash -n setup.sh`
- `shellcheck setup.sh`
- `python3 -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_b_68957f3298fc83298bcecf8251546894