### PR TITLE
Harden shell scripts with strict mode and safer expansions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+set -euo pipefail
 
 # Install UnityBotV4 as a systemd service on Linux
-set -e
 
 SERVICE_NAME="unitybot"
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
@@ -31,19 +31,19 @@ if [ ! -x "$VENV_PYTHON" ]; then
     exit 1
 fi
 
-cat <<EOF | $SUDO tee /etc/systemd/system/${SERVICE_NAME}.service >/dev/null
+cat <<EOF | $SUDO tee "/etc/systemd/system/${SERVICE_NAME}.service" >/dev/null
 [Unit]
 Description=UnityBot Discord Bot
 After=network.target
 
 [Service]
 Type=simple
-User=${RUN_USER}
-Group=${RUN_GROUP}
-WorkingDirectory=${SCRIPT_DIR}
-EnvironmentFile=-${SCRIPT_DIR}/.env
+User="${RUN_USER}"
+Group="${RUN_GROUP}"
+WorkingDirectory="${SCRIPT_DIR}"
+EnvironmentFile=-"${SCRIPT_DIR}/.env"
 EnvironmentFile=-/etc/environment
-ExecStart=${VENV_PYTHON} ${SCRIPT_DIR}/bot.py
+ExecStart="${VENV_PYTHON}" "${SCRIPT_DIR}/bot.py"
 Restart=on-failure
 
 [Install]
@@ -51,8 +51,8 @@ WantedBy=multi-user.target
 EOF
 
 $SUDO systemctl daemon-reload
-$SUDO systemctl enable ${SERVICE_NAME}
-$SUDO systemctl start ${SERVICE_NAME}
+$SUDO systemctl enable "${SERVICE_NAME}"
+$SUDO systemctl start "${SERVICE_NAME}"
 
 echo "Service ${SERVICE_NAME} installed and started."
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+set -euo pipefail
 
 # Setup script for UnityBotV4 on Linux
-set -e
 
 # Ensure the script runs from its own directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -64,7 +64,7 @@ fi
 source .venv/bin/activate
 
 prompt_var() {
-    local var_name=$1
+    local var_name="$1"
     local env_val
     env_val=$(printenv "$var_name" 2>/dev/null || true)
     local file_val=""
@@ -74,22 +74,22 @@ prompt_var() {
         if [[ -n "$file_val" ]]; then
             echo "$var_name already set in .env. Skipping prompt."
         else
-            read -r -p "Enter value for $var_name${env_val:+ [$env_val]}: " value
-            value=${value:-$env_val}
-            [[ -f .env ]] && grep -v "^$var_name=" .env > .env.tmp && mv .env.tmp .env
-            echo "$var_name=$value" >> .env
+            read -r -p "Enter value for ${var_name}${env_val:+ [${env_val}]}: " value
+            value="${value:-${env_val}}"
+            [[ -f .env ]] && grep -v "^${var_name}=" .env > .env.tmp && mv .env.tmp .env
+            echo "${var_name}=${value}" >> .env
         fi
     else
         if [[ -n "$env_val" ]]; then
             echo "$var_name already set. Skipping prompt."
         else
-            read -r -p "Enter value for $var_name: " value
-            if grep -q "^$var_name=" /etc/environment 2>/dev/null; then
-                sudo sed -i "s/^$var_name=.*/$var_name=\"${value}\"/" /etc/environment
+            read -r -p "Enter value for ${var_name}: " value
+            if grep -q "^${var_name}=" /etc/environment 2>/dev/null; then
+                sudo sed -i "s/^${var_name}=.*/${var_name}=\"${value}\"/" /etc/environment
             else
-                echo "$var_name=\"${value}\"" | sudo tee -a /etc/environment >/dev/null
+                echo "${var_name}=\"${value}\"" | sudo tee -a /etc/environment >/dev/null
             fi
-            export "$var_name"="$value"
+            export "${var_name}"="${value}"
         fi
     fi
 }


### PR DESCRIPTION
## Summary
- enforce `set -euo pipefail` in install and setup scripts
- quote variable expansions when generating service files and updating `/etc/environment`

## Testing
- `shellcheck install.sh setup.sh`
- `bash -n install.sh setup.sh`


------
https://chatgpt.com/codex/tasks/task_b_689a82d38d208329bd369bfb1cc80fbe