### PR TITLE
Avoid logging token substrings

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,28 +20,38 @@ class Config:
         self.discord_token = os.getenv("DISCORD_TOKEN")
         if self.discord_token:
             self.discord_token = self.discord_token.strip()  # Remove whitespace
-            logger.debug(f"Discord token length: {len(self.discord_token)}, first 10 chars: {self.discord_token[:10]}")
+            logger.debug(f"Discord token length: {len(self.discord_token)}")
             # Discord tokens are base64-like, ~59-100 chars
             if not re.match(r'^[A-Za-z0-9._-]{50,100}$', self.discord_token):
-                logger.error(f"Invalid Discord token format: {self.discord_token[:10]}... (truncated)")
+                logger.error(
+                    "Invalid Discord token format (length: %d)", len(self.discord_token)
+                )
                 raise ValueError("Invalid Discord token format. Ensure no spaces, quotes, or invalid characters.")
         else:
             logger.error("DISCORD_TOKEN not found in environment variables")
             raise ValueError("DISCORD_TOKEN not found in environment variables")
-        logger.info(f"Successfully loaded discord token: {self.discord_token[:10]}... (truncated for security)")
+        logger.info(
+            "Successfully loaded discord token (length: %d)", len(self.discord_token)
+        )
 
         # Load and validate Pollinations token
         self.pollinations_token = os.getenv("POLLINATIONS_TOKEN")
         if self.pollinations_token:
             self.pollinations_token = self.pollinations_token.strip()
-            logger.debug(f"Pollinations token length: {len(self.pollinations_token)}, first 10 chars: {self.pollinations_token[:10]}")
+            logger.debug(f"Pollinations token length: {len(self.pollinations_token)}")
             if not re.match(r'^[A-Za-z0-9]{16}$', self.pollinations_token):  # Assuming 16-char alphanumeric format from example
-                logger.error(f"Invalid Pollinations token format: {self.pollinations_token[:10]}... (truncated)")
+                logger.error(
+                    "Invalid Pollinations token format (length: %d)",
+                    len(self.pollinations_token),
+                )
                 raise ValueError("Invalid Pollinations token format. Ensure it's correct and no invalid characters.")
         else:
             logger.error("POLLINATIONS_TOKEN not found in environment variables")
             raise ValueError("POLLINATIONS_TOKEN not found in environment variables")
-        logger.info(f"Successfully loaded pollinations token: {self.pollinations_token[:10]}... (truncated for security)")
+        logger.info(
+            "Successfully loaded pollinations token (length: %d)",
+            len(self.pollinations_token),
+        )
 
         # Bot configuration
         self.default_model = "unity"


### PR DESCRIPTION
## Summary
- Avoid logging Discord and Pollinations token substrings, logging only token lengths

## Testing
- `python -m py_compile config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689a8485898c832994b81ea0fc91af44