### PR TITLE
Improve setup script configuration prompts and Linux compatibility

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-DISCORD_TOKEN=YourTokenHere
-POLLINATIONS_TOKEN=YourTokenHere

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DISCORD_TOKEN=YourDiscordTokenHere
+POLLINATIONS_TOKEN=YourPollinationsTokenHere
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 # .gitignore
 
-# Files
+# Python cache
+__pycache__/
 
-# Folders
+# Virtual environment
+.venv/
+
+# Local environment variables
+.env
+


### PR DESCRIPTION
## Summary
- Prompt for configuration values when `.env` or system env vars are missing or placeholders
- Add `SUDO` fallback to support running as non-root and update installation commands
- Introduce `.env.example` and gitignore rules for environment files

## Testing
- `bash -n setup.sh`
- `python -m py_compile bot.py commands.py config.py data_manager.py api_client.py memory_manager.py message_handler.py`


------
https://chatgpt.com/codex/tasks/task_b_68a43c83b9c083298ab72a121fa0febd