### PR TITLE
Add channel allowlist and bot response delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Examples:
 ## Config Tweaks
 
 - Edit `config.py`: `max_history` (20), `max_memories` (5), add code/image keywords
+- Optionally set `ALLOWED_CHANNELS` in `.env` to comma-separated channel IDs the bot may respond in
 - Edit `system_instructions.txt` for AI style
 
 ## Security

--- a/bot.py
+++ b/bot.py
@@ -56,6 +56,15 @@ async def on_ready():
 async def on_message(message):
     if message.author == bot.user:
         return
+    if message.guild and config.allowed_channels and str(message.channel.id) not in config.allowed_channels:
+        logging.info(
+            f"Ignoring message in unauthorized channel {message.channel.id}"
+        )
+        return
+
+    if message.author.bot:
+        logging.info(f"Delaying response to bot {message.author.id} by 10 seconds")
+        await asyncio.sleep(10)
 
     channel_id = str(message.channel.id)
     guild_id = str(message.guild.id) if message.guild else "DM"

--- a/config.py
+++ b/config.py
@@ -65,6 +65,10 @@ class Config:
         self.models_url = "https://text.pollinations.ai/models"
         self.max_history = 20
         self.max_memories = 5
+        allowed_channels_env = os.getenv("ALLOWED_CHANNELS", "")
+        self.allowed_channels = {
+            ch.strip() for ch in allowed_channels_env.split(",") if ch.strip()
+        }
         self.code_keywords = [
             "code", "script", "program", "function", "class",
             "method", "javascript", "python", "java", "html", "css"


### PR DESCRIPTION
## Summary
- allow configuring allowed Discord channels via `ALLOWED_CHANNELS` env var
- prevent replies outside allowed channels and pause 10s before replying to other bots
- document new `ALLOWED_CHANNELS` configuration

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68b5844af3988329b79aea4dcfe895af